### PR TITLE
Add ‘not’ options for AlignmentFilter

### DIFF
--- a/app/models/alignment_filter.rb
+++ b/app/models/alignment_filter.rb
@@ -29,9 +29,9 @@ class AlignmentFilter
   def filtered_alignments
     alignments = ALIGNMENTS.dup
     alignment_options.each do |option|
-      if option.to_s.include?("not")
-        not_option = option.to_s.split("_").last
-        alignments.select! { |a| !a.to_s.include? not_option }
+      reg = /not_(?<not_option>\w+)/.match(option.to_s)
+      if reg
+        alignments.select! { |a| !a.to_s.include? reg[:not_option] }
       else
         alignments.select! { |a| a.to_s.include? option.to_s }
       end
@@ -40,9 +40,7 @@ class AlignmentFilter
   end
 
   def alignment_options
-    options = []
-    options << alignment
-    options.flatten
+    [alignment].flatten
   end
 
   def allow_all?

--- a/app/models/alignment_filter.rb
+++ b/app/models/alignment_filter.rb
@@ -27,9 +27,22 @@ class AlignmentFilter
   private
 
   def filtered_alignments
-    ALIGNMENTS.select do |a|
-      a if a.to_s.include? alignment.to_s
+    alignments = ALIGNMENTS.dup
+    alignment_options.each do |option|
+      if option.to_s.include?("not")
+        not_option = option.to_s.split("_").last
+        alignments.select! { |a| !a.to_s.include? not_option }
+      else
+        alignments.select! { |a| a.to_s.include? option.to_s }
+      end
     end
+    alignments
+  end
+
+  def alignment_options
+    options = []
+    options << alignment
+    options.flatten
   end
 
   def allow_all?

--- a/spec/models/aligntment_filter_spec.rb
+++ b/spec/models/aligntment_filter_spec.rb
@@ -43,5 +43,39 @@ describe AlignmentFilter do
         end
       end
     end
+
+    describe "using 'not'" do
+      describe "evil" do
+        before do
+          @filter = AlignmentFilter.new(:not_evil)
+        end
+
+        it "doesn't return evil alignments" do
+          expect(@filter.remaining_options).to include(:lawful_good, :lawful_neutral, :chaotic_good,
+                                                       :chaotic_neutral, :true_neutral, :neutral_good)
+        end
+      end
+
+      describe "chaotic" do
+        before do
+          @filter = AlignmentFilter.new(:not_chaotic)
+        end
+
+        it "doesn't return chaotic alignments" do
+          expect(@filter.remaining_options).to contain_exactly(:lawful_good, :lawful_evil, :lawful_neutral,
+                                                       :true_neutral, :neutral_good, :neutral_evil)
+        end
+      end
+
+      describe "chaotic and not good" do
+        before do
+          @filter = AlignmentFilter.new([:not_good, :chaotic])
+        end
+
+        it "returns chaotic but not good alignments" do
+          expect(@filter.remaining_options).to contain_exactly(:chaotic_neutral, :chaotic_evil)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Alignments can be declared as either allowing or forbidding certain options. Options can be passed individually (AlignmentFilter.new(:good), AlignmentFilter.new(:not_chaotic)) or as an array of options, such as AlignmentFilter.new([:not_good, :chaotic]).

Related to issue #5
